### PR TITLE
New Config Settting: pep8.lintOnSave

### DIFF
--- a/lib/pep8.coffee
+++ b/lib/pep8.coffee
@@ -7,37 +7,25 @@ Pep8ErrorsView = require './pep8-view'
 module.exports =
     supportedExtensions: [".py"]
     errorView: null
-    pep8Path: null
 
-    defaultConfig:
-        'pep8.PEP8Path': '/usr/local/bin/pep8',
-        'pep8.ignoreErrors': []
-    boundObservers: false
-
-    loadConfig: ->
-
-        if not @boundObservers
-            for config_key, default_val of @defaultConfig
-                atom.config.observe(config_key, {}, @loadConfig)
-            @boundObservers = true
-
-        console.log "PEP8 Liner: Loading config"
-
-        for config_key, default_val of @defaultConfig
-            unless atom.config.get(config_key)
-                atom.config.set(config_key, default_val)
-
-        @pep8Path = atom.config.get('pep8.PEP8Path')
-        @ignoreErrors = atom.config.get('pep8.ignoreErrors')
+    initConfig: ->
+      atom.config.setDefaults('pep8',
+        PEP8Path: '/usr/local/bin/pep8',
+        ignoreErrors: [],
+        lintOnSave: true
+      )
 
     activate: ->
-        @loadConfig()
-        
+        @initConfig()
+
         atom.workspaceView.command 'pep8:lint', =>
             @lint()
 
         atom.workspaceView.command 'core:save', =>
-            @lint()
+            @onSave()
+
+    onSave: ->
+        @lint() if atom.config.get('pep8.lintOnSave')
 
     lint: ->
         editor = atom.workspace.getActiveEditor()
@@ -61,9 +49,12 @@ module.exports =
         line_expr = /:(\d+):(\d+): (E\d{3}) (.*)/
         errors = []
 
-        return unless @pep8Path
+        pep8Path = atom.config.get('pep8.PEP8Path')
+        ignoreErrors = atom.config.get('pep8.ignoreErrors')
 
-        proc = process.spawn(@pep8Path, [path])
+        return unless pep8Path
+
+        proc = process.spawn(pep8Path, [path])
 
         # Watch for pep8 errors
         output = byline(proc.stdout)
@@ -74,7 +65,7 @@ module.exports =
             if matches
                 [_, line, position, type, message] = matches
 
-                if type in @ignoreErrors
+                if type in ignoreErrors
                     return # Skip errors the user has chosen to ignore
 
                 errors.push {

--- a/lib/pep8.coffee
+++ b/lib/pep8.coffee
@@ -32,6 +32,9 @@ module.exports =
 
     activate: ->
         @loadConfig()
+        
+        atom.workspaceView.command 'pep8:lint', =>
+            @lint()
 
         atom.workspaceView.command 'core:save', =>
             @lint()

--- a/menus/pep8.json
+++ b/menus/pep8.json
@@ -1,0 +1,18 @@
+{
+  "menu":[
+    {
+      "label": "Packages",
+      "submenu": [
+        {
+          "label": "PEP8",
+          "submenu": [
+              {
+                "label": "Lint",
+                "command": "pep8:lint"
+              }
+            ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello
I've implemented the following:
- Added a pep8.lintOnSave config setting that decides whether not to lint automatically when the file is saved (as suggested in #2)
- Added a PEP8 menu with a "Lint" option to manually trigger linting
- Setup default config settings using Atom's atom.config.setDefaults API
